### PR TITLE
feat(#21): responsive overlay badge implementation

### DIFF
--- a/src/VivaLaResistance/Controls/ResistorOverlayDrawable.cs
+++ b/src/VivaLaResistance/Controls/ResistorOverlayDrawable.cs
@@ -17,17 +17,27 @@ public sealed class ResistorOverlayDrawable : IDrawable
     private const double YellowThreshold = 0.65;
 
     // ── Badge layout constants ────────────────────────────────────────────────
-    private const float BadgePaddingH    = 10f;
-    private const float BadgePaddingV    = 6f;
     private const float BadgeCornerRadius = 8f;
-    private const float BadgeMinWidth    = 80f;
-    private const float BadgeMaxWidth    = 160f;
-    private const float BadgeHeight      = 46f;  // two text lines + padding
-    private const float BadgeGapAboveBox = 6f;
-    private const float DotRadius        = 5f;
+    private const float BadgeGapAboveBox  = 6f;
 
-    private const float ValueFontSize     = 13f;
-    private const float ToleranceFontSize = 10f;
+    // Responsive metrics are computed per draw call via GetBreakpointMetrics().
+    private readonly record struct BadgeMetrics(
+        float ValueFontSize,
+        float ToleranceFontSize,
+        float BadgeHeight,
+        float PaddingH,
+        float PaddingV,
+        float MinWidth,
+        float MaxWidth,
+        float DotRadius);
+
+    // Breakpoint thresholds (dp): Compact < 400, Standard 400–599, Expanded ≥ 600.
+    private static BadgeMetrics GetBreakpointMetrics(float viewW) => viewW switch
+    {
+        < 400f => new BadgeMetrics(14f, 10f, 38f, 6f,  4f,  60f, 160f, 4f),
+        < 600f => new BadgeMetrics(16f, 12f, 42f, 8f,  6f,  80f, 160f, 5f),
+        _      => new BadgeMetrics(18f, 14f, 46f, 10f, 6f, 100f, 200f, 6f),
+    };
 
     // Visible badges keyed by ResistorReading.Id (Guid).
     // Separate sets track which IDs are "active" for hysteresis logic.
@@ -94,24 +104,36 @@ public sealed class ResistorOverlayDrawable : IDrawable
 
     private static void DrawBadge(ICanvas canvas, ResistorReading reading, float viewW, float viewH)
     {
+        var m   = GetBreakpointMetrics(viewW);
         var box = reading.BoundingBox;
 
         float boxLeft   = box.X      * viewW;
         float boxTop    = box.Y      * viewH;
+        float boxBottom = (box.Y + box.Height) * viewH;
         float boxWidth  = box.Width  * viewW;
 
-        // Badge width clamped to reasonable range, centered on the bounding box
-        float badgeW = Math.Clamp(boxWidth, BadgeMinWidth, BadgeMaxWidth);
-        float badgeH = BadgeHeight;
+        // Badge width clamped to breakpoint-specific range, centered on the bounding box
+        float badgeW = Math.Clamp(boxWidth, m.MinWidth, m.MaxWidth);
+        float badgeH = m.BadgeHeight;
 
-        float centerX  = boxLeft + boxWidth / 2f;
-        float badgeX   = centerX - badgeW / 2f;
-        float badgeY   = Math.Max(4f, boxTop - badgeH - BadgeGapAboveBox);
+        float centerX = boxLeft + boxWidth / 2f;
+        float badgeX  = centerX - badgeW / 2f;
+
+        // Horizontal edge clamping: keep badge within the view
+        badgeX = Math.Max(4f, badgeX);
+        badgeX = Math.Min(viewW - badgeW - 4f, badgeX);
+
+        // Vertical placement: above the box normally; flip below when near the top edge
+        float badgeY;
+        if (boxTop - badgeH - BadgeGapAboveBox < 4f)
+            badgeY = Math.Min(boxBottom + BadgeGapAboveBox, viewH - badgeH - 4f);
+        else
+            badgeY = Math.Max(4f, boxTop - badgeH - BadgeGapAboveBox);
 
         canvas.SaveState();
 
-        // Background: dark semi-transparent rounded rectangle
-        canvas.FillColor   = Color.FromArgb("#CC1a1a2e");
+        // Background: pure black, 80% opacity — best universal contrast (spec §2.2)
+        canvas.FillColor = Color.FromArgb("#CC000000");
         canvas.FillRoundedRectangle(badgeX, badgeY, badgeW, badgeH, BadgeCornerRadius);
 
         // Thin border
@@ -120,19 +142,19 @@ public sealed class ResistorOverlayDrawable : IDrawable
         canvas.DrawRoundedRectangle(badgeX, badgeY, badgeW, badgeH, BadgeCornerRadius);
 
         // Confidence dot — top-right corner inside the badge
-        float dotX = badgeX + badgeW - DotRadius - 7f;
-        float dotY = badgeY + DotRadius + 7f;
+        float dotX = badgeX + badgeW - m.DotRadius - 7f;
+        float dotY = badgeY + m.DotRadius + 7f;
         canvas.FillColor = ConfidenceColor(reading.Confidence);
-        canvas.FillCircle(dotX, dotY, DotRadius);
+        canvas.FillCircle(dotX, dotY, m.DotRadius);
 
         // FormattedValue on the first line
-        float textMaxW = badgeW - BadgePaddingH * 2 - DotRadius * 2 - 6f;
+        float textMaxW = badgeW - m.PaddingH * 2 - m.DotRadius * 2 - 6f;
         canvas.FontColor = Colors.White;
-        canvas.FontSize  = ValueFontSize;
+        canvas.FontSize  = m.ValueFontSize;
         canvas.DrawString(
             reading.FormattedValue,
-            badgeX + BadgePaddingH,
-            badgeY + BadgePaddingV,
+            badgeX + m.PaddingH,
+            badgeY + m.PaddingV,
             textMaxW,
             20f,
             HorizontalAlignment.Left,
@@ -141,12 +163,12 @@ public sealed class ResistorOverlayDrawable : IDrawable
         // TolerancePercent on the second line
         string toleranceLine = $"\u00b1{reading.TolerancePercent:0.#}%";
         canvas.FontColor = Color.FromArgb("#CCBBBBBB");
-        canvas.FontSize  = ToleranceFontSize;
+        canvas.FontSize  = m.ToleranceFontSize;
         canvas.DrawString(
             toleranceLine,
-            badgeX + BadgePaddingH,
-            badgeY + BadgePaddingV + 19f,
-            badgeW - BadgePaddingH * 2,
+            badgeX + m.PaddingH,
+            badgeY + m.PaddingV + 19f,
+            badgeW - m.PaddingH * 2,
             16f,
             HorizontalAlignment.Left,
             VerticalAlignment.Top);


### PR DESCRIPTION
## Summary
Implements the v1.0 High Priority items from Hope's overlay badge spec (design/overlay-badge-spec.md, PR #55).

## Changes
- **Responsive sizing**: font sizes, padding, height, min/max width all adapt to screen breakpoint
- **Background color**: #CC1a1a2e → #CC000000 (pure black, better contrast)
- **Horizontal edge clamping**: badges never escape the left/right screen edges
- **Vertical flip**: badge renders below the resistor when near the top of screen

## Breakpoints
- Compact (<400dp): 14sp value, 38dp height, 60dp min width
- Standard (400-599dp): 16sp value, 42dp height, 80dp min width
- Expanded (≥600dp): 18sp value, 46dp height, 100dp min width

Spec: design/overlay-badge-spec.md
Related: PR #55 (design spec)